### PR TITLE
Fixes issue #3 - For the benefit of IE, generate access control headers with comma separa...

### DIFF
--- a/lib/Plack/Middleware/CrossOrigin.pm
+++ b/lib/Plack/Middleware/CrossOrigin.pm
@@ -165,10 +165,8 @@ sub call {
         if (defined $self->max_age) {
             push @headers, 'Access-Control-Max-Age' => $self->max_age;
         }
-        push @headers, 'Access-Control-Allow-Methods' => $_
-            for @$allowed_methods;
-        push @headers, 'Access-Control-Allow-Headers' => $_
-            for @$allowed_headers;
+        push @headers, 'Access-Control-Allow-Methods' => join ', ', @$allowed_methods;
+        push @headers, 'Access-Control-Allow-Headers' => join ', ', @$allowed_headers;
 
         $res = _response_success();
     }
@@ -185,8 +183,7 @@ sub call {
             $expose_headers = [keys %headers];
         }
 
-        push @headers, 'Access-Control-Expose-Headers' => $_
-            for @$expose_headers;
+        push @headers, 'Access-Control-Expose-Headers' => join ', ', @$expose_headers;
 
         push @{ $res->[1] }, @headers;
     });


### PR DESCRIPTION
...ted values

rather than a header for each value. It appears that at least IE 11 only looks at
the first 'Access-Control-Allow-Headers' header.
