### PR TITLE
Add "Vary: Origin" header to responses

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Plack-Middleware-CrossOrigin
 
 {{$NEXT}}
+ - Always add a "Vary: Origin" header to avoid issues with caches
 
 0.012     Dec 07 2014
  - Include real change log entry for 0.011

--- a/lib/Plack/Middleware/CrossOrigin.pm
+++ b/lib/Plack/Middleware/CrossOrigin.pm
@@ -111,7 +111,11 @@ sub call {
         $continue_on_failure = 1;
     }
     else {
-        return $self->app->($env);
+        return Plack::Util::response_cb($self->app->($env), sub {
+            my $res = shift;
+            _add_vary($res->[1]);
+            return;
+        });
     }
 
     my $request_method  = $env->{HTTP_ACCESS_CONTROL_REQUEST_METHOD};
@@ -135,7 +139,11 @@ sub call {
         # allow request to proceed
     }
     elsif ( ! $allowed_origins_h->{$origin} ) {
-        return $fail->($env);
+        return Plack::Util::response_cb($fail->($env), sub {
+            my $res = shift;
+            _add_vary($res->[1]);
+            return;
+        });
     }
 
     if ($preflight) {
@@ -177,6 +185,7 @@ sub call {
     return $self->response_cb($res, sub {
         my $res = shift;
 
+        _add_vary($res->[1]);
         if ($expose_headers_h->{'*'}) {
             my %headers = @{ $res->[1] };
             delete @headers{@simple_response_headers};
@@ -190,11 +199,20 @@ sub call {
 }
 
 sub _response_forbidden {
-    [403, ['Content-Type' => 'text/plain', 'Content-Length' => 9], ['forbidden']];
+    [403, ['Content-Type' => 'text/plain', 'Content-Length' => 9, 'Vary' => 'Origin'], ['forbidden']];
 }
 
 sub _response_success {
     [200, [ 'Content-Type' => 'text/plain' ], [] ];
+}
+
+sub _add_vary {
+    my ($headers) = @_;
+
+    unless (grep { m{^\s*Origin\s*$}i } map { split /,/ } Plack::Util::header_get($headers, 'Vary')) {
+        push @{ $headers }, 'Vary' => 'Origin';
+    }
+    return;
 }
 
 1;

--- a/lib/Plack/Middleware/CrossOrigin.pm
+++ b/lib/Plack/Middleware/CrossOrigin.pm
@@ -242,6 +242,9 @@ This module attempts to fully conform to the CORS spec, while
 allowing additional flexibility in the values specified for the of
 the headers.
 
+The module also ensures that the response contains a C<Vary: Origin>
+header to avoid potential issues with caches.
+
 =head1 CORS REQUESTS IN BRIEF
 
 There are two types of CORS requests.  Simple requests, and preflighted
@@ -390,6 +393,7 @@ Opera and Opera Mobile support CORS since version 12.
 
 =for :list
 * L<W3C Spec for Cross-Origin Resource Sharing|http://www.w3.org/TR/cors/>
+* L<W3C Spec for Cross-Origin Resource Sharing - Implementation Considerations|http://www.w3.org/TR/cors/#resource-implementation>
 * L<Mozilla Developer Center - HTTP Access Control|https://developer.mozilla.org/En/HTTP_access_control>
 * L<Mozilla Developer Center - Server-Side Access Control|https://developer.mozilla.org/En/Server-Side_Access_Control>
 * L<Cross browser examples of using CORS requests|http://www.nczonline.net/blog/2010/05/25/cross-domain-ajax-with-cross-origin-resource-sharing/>

--- a/t/basic.t
+++ b/t/basic.t
@@ -25,7 +25,8 @@ test_psgi
 
         $req = HTTP::Request->new(GET => 'http://localhost/');
         $res = $cb->($req);
-        is $res->header('Access-Control-Allow-Origin'), undef, 'No extra headers added with no Origin header';
+        is $res->header('Access-Control-Allow-Origin'), undef, 'No CORS headers added with no Origin header';
+        is $res->header('Vary'), 'Origin', '... but Vary header added';
 
         $req = HTTP::Request->new(GET => 'http://localhost/', [
             'Origin' => 'http://www.example.com',
@@ -34,6 +35,7 @@ test_psgi
         is $res->header('Access-Control-Allow-Origin'), '*', 'Access-Control-Allow-Origin header added';
         is $res->header('Access-Control-Expose-Headers'), 'X-Exposed-Header', 'Access-Control-Expose-Headers header added';
         is $res->header('Access-Control-Max-Age'), undef, 'No Max-Age header for simple request';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
         is $res->content, 'Hello World', "CORS handling doesn't interfere with request content";
 
         $req = HTTP::Request->new(OPTIONS => 'http://localhost/', [
@@ -43,6 +45,7 @@ test_psgi
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), '*', 'Access-Control-Allow-Origin header added for preflight';
         is $res->header('Access-Control-Allow-Methods'), 'POST', 'Access-Control-Allow-Methods header added for preflight';
+        is $res->header('Vary'), 'Origin', 'Vary header added for preflight';
         is $res->header('Access-Control-Max-Age'), 60*60*24*30, 'Max-Age header added for preflight';
 
         $req = HTTP::Request->new(OPTIONS => 'http://localhost/', [
@@ -52,6 +55,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         ok $res->header('Access-Control-Allow-Origin'), 'Request with extra headers allowed';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         $req = HTTP::Request->new(GET => 'http://localhost/', [
             'Referer' => 'http://www.example.com/page',
@@ -59,6 +63,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), '*', 'Buggy GET request from WebKit includes Allow-Origin header';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         $req = HTTP::Request->new(GET => 'http://localhost/', [
             'Referer' => 'http://www.example.com/page',
@@ -66,6 +71,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), undef, 'New versions of WebKit don\'t trigger referer workaround';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         my @warnings;
         local $SIG{__WARN__} = sub { push @warnings, join '', @_ };
@@ -74,6 +80,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), undef, 'Buggy GET request from WebKit without Referer does not include Allow-Origin header';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
         is_deeply \@warnings, [], 'No warnings from buggy WebKit request';
     };
 
@@ -106,6 +113,7 @@ test_psgi
         is $res->header('Access-Control-Allow-Origin'), 'http://www.example.com', 'Explicitly listed origin returned';
         is $res->header('Access-Control-Allow-Headers'), 'X-Extra-Header, X-Extra-Header-2', 'Allowed headers returned';
         is $res->header('Access-Control-Allow-Methods'), 'GET, POST', 'Allowed methods returned';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         $req = HTTP::Request->new(OPTIONS => 'http://localhost/', [
             'Access-Control-Request-Method' => 'POST',
@@ -114,6 +122,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), undef, 'Request with unmatched extra header rejected';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         $req = HTTP::Request->new(OPTIONS => 'http://localhost/', [
             'Access-Control-Request-Method' => 'POST',
@@ -121,6 +130,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), undef, 'Request with unmatched origin rejected';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         $req = HTTP::Request->new(OPTIONS => 'http://localhost/', [
             'Access-Control-Request-Method' => 'DELETE',
@@ -128,13 +138,15 @@ test_psgi
         ]);
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), undef, 'Request with unmatched method rejected';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         $req = HTTP::Request->new(OPTIONS => 'http://localhost/', [
             'Origin' => 'http://www.example.com',
         ]);
         $res = $cb->($req);
         is $res->content, 'Hello World', 'OPTIONS request without Allow-Origin processes as normal';
-        is $res->header('Access-Control-Expose-Headers'), 'X-Some-Other-Header', 'Wildcard expose headers returned';
+        like $res->header('Access-Control-Expose-Headers'), qr{^(?:X-Some-Other-Header, Vary|Vary, X-Some-Other-Header)$}, 'Wildcard expose headers returned';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         $req = HTTP::Request->new(GET => 'http://localhost/', [
             'Referer' => 'http://www.example.com/page',
@@ -142,6 +154,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), 'http://www.example.com', 'Buggy GET request from WebKit includes Allow-Origin header based on referer';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
 
         $req = HTTP::Request->new(GET => 'http://localhost/', [
             'Referer' => 'http://www.example.com/page',
@@ -149,6 +162,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Origin'), undef, 'New versions of WebKit don\'t trigger referer workaround';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
     };
 
 test_psgi
@@ -172,6 +186,7 @@ test_psgi
         $res = $cb->($req);
         is $res->header('Access-Control-Allow-Credentials'), 'true', 'Resource with credentials adds correct header';
         is $res->header('Access-Control-Allow-Origin'), 'http://www.example.com', '... and an explicit origin';
+        is $res->header('Vary'), 'Origin', '... and the Vary header';
     };
 
 my $has_run;
@@ -196,6 +211,7 @@ test_psgi
         $res = $cb->($req);
         is $res->code, 403, 'Disallowed simple request returns 403 error';
         ok ! $has_run, ' ... and aborts before running main app';
+        is $res->header('Vary'), 'Origin', ' ... but still adds the Vary header';
 
         $has_run = 0;
         $req = HTTP::Request->new(GET => 'http://localhost/', [
@@ -204,6 +220,7 @@ test_psgi
         ]);
         $res = $cb->($req);
         ok $has_run, 'WebKit workaround always allows app to run';
+        is $res->header('Vary'), 'Origin', 'Vary header added';
     };
 
 test_psgi
@@ -230,6 +247,7 @@ test_psgi
         ok $has_run, 'continue_on_failure allows main app to run for simple requests';
         is $res->code, 200, ' ... and passes through results';
         is $res->header('Access-Control-Allow-Origin'), undef, ' ... and doesn\'t add headers to allow CORS';
+        is $res->header('Vary'), 'Origin', ' ... but adds the Vary header';
 
         $has_run = 0;
         $req = HTTP::Request->new(OPTIONS => 'http://localhost/', [
@@ -238,7 +256,39 @@ test_psgi
         ]);
         $res = $cb->($req);
         ok ! $has_run, 'continue_on_failure doesn\'t run main app for preflighted request';
+        is $res->header('Vary'), 'Origin', ' ... but adds the Vary header';
     };
+
+{
+    my @headers = ('Content-Type' => 'text/plain', 'Vary' => 'Accept-Language');
+    test_psgi
+        app => builder {
+            enable 'CrossOrigin',
+                origins => 'http://localhost',
+            ;
+            sub {
+                [ 200, [ @headers ], [ 'Hello World' ] ];
+            };
+        },
+        client => sub {
+            my $cb = shift;
+            my $req;
+            my $res;
+
+            $req = HTTP::Request->new(GET => 'http://localhost/', [
+                'Origin' => 'http://localhost',
+            ]);
+            $res = $cb->($req);
+            is $res->header('Vary'), 'Accept-Language, Origin', 'Vary header extended';
+
+            unshift @headers, 'Vary' => 'Origin';
+            $req = HTTP::Request->new(GET => 'http://localhost/', [
+                'Origin' => 'http://localhost',
+            ]);
+            $res = $cb->($req);
+            is $res->header('Vary'), 'Origin, Accept-Language', 'Vary header not duplicated';
+        };
+}
 
 {
    # Test that the access control headers are returned as single headers
@@ -270,6 +320,7 @@ test_psgi
       200,
       [
          'Content-Type'                  => 'text/plain',
+         'Vary'                          => 'Origin',
          'Access-Control-Allow-Origin'   => 'http://www.example.com',
          'Access-Control-Allow-Methods'  => 'GET, POST',
          'Access-Control-Allow-Headers'  => 'X-Extra-Header, X-Extra-Header-2',


### PR DESCRIPTION
Hi,

I recently ran into a caching problem with browser caching and CORS while using this middleware. 
The application which uses it delivers images, which are cacheable and used with `<img>` tags, but also in a canvas (which requires them to have the `Access-Control-Allow-Origin` header set for the things I'm doing)  - however, if the image is loaded in the `<img>` tag first, the object in the cache will not have the `Access-Control-Allow-Origin` header set, which resulted in a security error when using it in the canvas. I found two solutions for this, one is adding the `crossorigin` attribute to the `<img>` tag as well (which is not ideal since one has to do this in every place where the image is used, and also only works if the image is used on only one single origin), and the other is adding the `Vary: Origin` header in the application. Both solutions basically work, but I think it would be better if this was already handled by the middleware, which is why I'm creating this pull request, which always adds the `Vary` header.
The ["Cross-Origin Resource Sharing" specification](http://www.w3.org/TR/cors/#resource-implementation) also says that this or something similar should be done if the application does not always set the `Access-Control-Allow-Origin: *` header, and I also found [a Varnish-specific article about "Caching with CORS" ](https://www.fastly.com/blog/caching-cors) pretty interesting. 

Kind regards
Manfred
