### PR TITLE
Updated methods to include RFCs 7231 and 5789

### DIFF
--- a/lib/Plack/Middleware/CrossOrigin.pm
+++ b/lib/Plack/Middleware/CrossOrigin.pm
@@ -40,11 +40,24 @@ my @common_headers = qw(
     X-Requested-With
     X-Prototype-Version
 );
+
+# RFC 7231
 my @http_methods = qw(
     GET
     HEAD
     POST
+    PUT
+    DELETE
+    CONNECT
+    OPTIONS
+    TRACE
 );
+
+# RFC 5789
+my @rfc_5789_methods = qw(
+    PATCH
+);
+
 my @webdav_methods = (@http_methods, qw(
     CANCELUPLOAD
     CHECKIN
@@ -64,7 +77,9 @@ my @webdav_methods = (@http_methods, qw(
     UNLOCK
     UPDATE
     VERSION-CONTROL
-));
+);
+
+my @all_methods = ( @http_methods, @rfc_5789_methods, @webdav_methods );
 
 sub prepare_app {
     my ($self) = @_;
@@ -72,7 +87,7 @@ sub prepare_app {
     $self->origins([$self->origins || ()])
         unless ref $self->origins;
 
-    $self->methods([$self->methods || @webdav_methods])
+    $self->methods([$self->methods || @all_methods])
         unless ref $self->methods;
 
     $self->headers([$self->headers || @common_headers])


### PR DESCRIPTION
These RFCs extend the original HTTP/1.0 methods in RFC 1945 and introduce PATCH which is used in REST APIs. This resolves Issue #6 